### PR TITLE
Adding project for Frameworks hackathon

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Several Frames have already adopted the Open Frames standard, showcasing the ver
 - [Interactive Polls](https://github.com/xmtp-labs/fc-polls): Engage your audience with real-time polls.
 - [rock-paper-scissors](https://github.com/Unshut-Labs/xmtp-frame-rock-paper-scissors): Rock paper scissors game.
 - [farcaster-gallery](https://github.com/Nith567/far): Gallery farcaster.
+- [Only Frames](https://github.com/Open-Sorcerer/onlyframes): Sell digital assets with your frames. 
 
 **others**
 


### PR DESCRIPTION
Adding the project [OnlyFrames](https://github.com/Open-Sorcerer/onlyframes) as we made it interoperable with Open Frames Standard 