### PR TITLE
Add Op cast

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Several Frames have already adopted the Open Frames standard, showcasing the ver
 - [Interactive Polls](https://github.com/xmtp-labs/fc-polls): Engage your audience with real-time polls.
 - [rock-paper-scissors](https://github.com/Unshut-Labs/xmtp-frame-rock-paper-scissors): Rock paper scissors game.
 - [farcaster-gallery](https://github.com/Nith567/far): Gallery farcaster.
-
+- [Op Cast](https://github.com/aeyshubh?tab=repositories): Op Cast ~ Transfer Axelar Interchain tokens from frame
 **others**
 
 - [Zora is a Magic Machine](https://paragraph.xyz/@zora/zora-magic-machine): Zora newsletter through Paragraph.


### PR DESCRIPTION
OP Cast is a frame using which you can move your Axelar interchain token from Optimism to base.